### PR TITLE
Allow whitespace between "void" and "*", adding some more missing OpenGL functions

### DIFF
--- a/auto-xs.inc
+++ b/auto-xs.inc
@@ -10231,6 +10231,17 @@ glGetPolygonStipple(mask);
 CODE:
     glGetPolygonStipple(mask);
 
+void *
+glGetProcAddressREGAL(name);
+     const GLchar *name;
+CODE:
+    if(! __glewGetProcAddressREGAL) {
+        croak("glGetProcAddressREGAL not available on this machine");
+    };
+    RETVAL = glGetProcAddressREGAL(name);
+OUTPUT:
+    RETVAL
+
 void
 glGetProgramBinary(program, bufSize, length, binaryFormat, binary);
      GLuint program;
@@ -13682,6 +13693,32 @@ CODE:
 OUTPUT:
     RETVAL
 
+void *
+glMapBufferARB(target, access);
+     GLenum target;
+     GLenum access;
+CODE:
+    if(! __glewMapBufferARB) {
+        croak("glMapBufferARB not available on this machine");
+    };
+    RETVAL = glMapBufferARB(target, access);
+OUTPUT:
+    RETVAL
+
+void *
+glMapBufferRange(target, offset, length, access);
+     GLenum target;
+     GLintptr offset;
+     GLsizeiptr length;
+     GLbitfield access;
+CODE:
+    if(! __glewMapBufferRange) {
+        croak("glMapBufferRange not available on this machine");
+    };
+    RETVAL = glMapBufferRange(target, offset, length, access);
+OUTPUT:
+    RETVAL
+
 void
 glMapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points);
      GLenum target;
@@ -13737,6 +13774,69 @@ glMapGrid2f(un, u1, u2, vn, v1, v2);
 CODE:
     glMapGrid2f(un, u1, u2, vn, v1, v2);
 
+void *
+glMapNamedBuffer(buffer, access);
+     GLuint buffer;
+     GLenum access;
+CODE:
+    if(! __glewMapNamedBuffer) {
+        croak("glMapNamedBuffer not available on this machine");
+    };
+    RETVAL = glMapNamedBuffer(buffer, access);
+OUTPUT:
+    RETVAL
+
+void *
+glMapNamedBufferEXT(buffer, access);
+     GLuint buffer;
+     GLenum access;
+CODE:
+    if(! __glewMapNamedBufferEXT) {
+        croak("glMapNamedBufferEXT not available on this machine");
+    };
+    RETVAL = glMapNamedBufferEXT(buffer, access);
+OUTPUT:
+    RETVAL
+
+void *
+glMapNamedBufferRange(buffer, offset, length, access);
+     GLuint buffer;
+     GLintptr offset;
+     GLsizeiptr length;
+     GLbitfield access;
+CODE:
+    if(! __glewMapNamedBufferRange) {
+        croak("glMapNamedBufferRange not available on this machine");
+    };
+    RETVAL = glMapNamedBufferRange(buffer, offset, length, access);
+OUTPUT:
+    RETVAL
+
+void *
+glMapNamedBufferRangeEXT(buffer, offset, length, access);
+     GLuint buffer;
+     GLintptr offset;
+     GLsizeiptr length;
+     GLbitfield access;
+CODE:
+    if(! __glewMapNamedBufferRangeEXT) {
+        croak("glMapNamedBufferRangeEXT not available on this machine");
+    };
+    RETVAL = glMapNamedBufferRangeEXT(buffer, offset, length, access);
+OUTPUT:
+    RETVAL
+
+void *
+glMapObjectBufferATI(buffer);
+     GLuint buffer;
+CODE:
+    if(! __glewMapObjectBufferATI) {
+        croak("glMapObjectBufferATI not available on this machine");
+    };
+    RETVAL = glMapObjectBufferATI(buffer);
+OUTPUT:
+    RETVAL
+
 void
 glMapParameterfvNV(target, pname, params);
      GLenum target;
@@ -13758,6 +13858,21 @@ CODE:
         croak("glMapParameterivNV not available on this machine");
     };
     glMapParameterivNV(target, pname, params);
+
+void *
+glMapTexture2DINTEL(texture, level, access, stride, layout);
+     GLuint texture;
+     GLint level;
+     GLbitfield access;
+     GLint* stride;
+     GLenum *layout;
+CODE:
+    if(! __glewMapTexture2DINTEL) {
+        croak("glMapTexture2DINTEL not available on this machine");
+    };
+    RETVAL = glMapTexture2DINTEL(texture, level, access, stride, layout);
+OUTPUT:
+    RETVAL
 
 void
 glMapVertexAttrib1dAPPLE(index, size, u1, u2, stride, order, points);

--- a/lib/OpenGL/Modern.pm
+++ b/lib/OpenGL/Modern.pm
@@ -938,6 +938,7 @@ our @glFunctions = qw(
     glGetPointeri_vEXT
     glGetPointerv
     glGetPolygonStipple
+    glGetProcAddressREGAL
     glGetProgramBinary
     glGetProgramEnvParameterdvARB
     glGetProgramEnvParameterfvARB
@@ -1259,13 +1260,21 @@ our @glFunctions = qw(
     glMap2d
     glMap2f
     glMapBuffer
+    glMapBufferARB
+    glMapBufferRange
     glMapControlPointsNV
     glMapGrid1d
     glMapGrid1f
     glMapGrid2d
     glMapGrid2f
+    glMapNamedBuffer
+    glMapNamedBufferEXT
+    glMapNamedBufferRange
+    glMapNamedBufferRangeEXT
+    glMapObjectBufferATI
     glMapParameterfvNV
     glMapParameterivNV
+    glMapTexture2DINTEL
     glMapVertexAttrib1dAPPLE
     glMapVertexAttrib1fAPPLE
     glMapVertexAttrib2dAPPLE
@@ -3029,6 +3038,8 @@ our %EXPORT_TAGS_GL = (
                                             'glGetVertexArrayiv',
                                             'glInvalidateNamedFramebufferData',
                                             'glInvalidateNamedFramebufferSubData',
+                                            'glMapNamedBuffer',
+                                            'glMapNamedBufferRange',
                                             'glNamedBufferData',
                                             'glNamedBufferStorage',
                                             'glNamedBufferSubData',
@@ -3250,7 +3261,8 @@ our %EXPORT_TAGS_GL = (
                                            'glInvalidateTexSubImage'
                                          ],
           'GL_ARB_map_buffer_range' => [
-                                         'glFlushMappedBufferRange'
+                                         'glFlushMappedBufferRange',
+                                         'glMapBufferRange'
                                        ],
           'GL_ARB_matrix_palette' => [
                                        'glCurrentPaletteMatrixARB',
@@ -3672,6 +3684,7 @@ our %EXPORT_TAGS_GL = (
                                              'glGetBufferPointervARB',
                                              'glGetBufferSubDataARB',
                                              'glIsBufferARB',
+                                             'glMapBufferARB',
                                              'glUnmapBufferARB'
                                            ],
           'GL_ARB_vertex_program' => [
@@ -3844,6 +3857,7 @@ our %EXPORT_TAGS_GL = (
                                         'glSetFragmentShaderConstantATI'
                                       ],
           'GL_ATI_map_object_buffer' => [
+                                          'glMapObjectBufferATI',
                                           'glUnmapObjectBufferATI'
                                         ],
           'GL_ATI_pn_triangles' => [
@@ -4070,6 +4084,8 @@ our %EXPORT_TAGS_GL = (
                                             'glGetVertexArrayIntegervEXT',
                                             'glGetVertexArrayPointeri_vEXT',
                                             'glGetVertexArrayPointervEXT',
+                                            'glMapNamedBufferEXT',
+                                            'glMapNamedBufferRangeEXT',
                                             'glMatrixFrustumEXT',
                                             'glMatrixLoadIdentityEXT',
                                             'glMatrixLoadTransposedEXT',
@@ -4615,6 +4631,7 @@ our %EXPORT_TAGS_GL = (
                                       'glReadBufferRegion'
                                     ],
           'GL_LAYOUT_LINEAR_INTEL' => [
+                                        'glMapTexture2DINTEL',
                                         'glSyncTextureINTEL',
                                         'glUnmapTexture2DINTEL'
                                       ],
@@ -5264,6 +5281,9 @@ our %EXPORT_TAGS_GL = (
           'GL_REGAL_log' => [
                               'glLogMessageCallbackREGAL'
                             ],
+          'GL_REGAL_proc_address' => [
+                                       'glGetProcAddressREGAL'
+                                     ],
           'GL_SGIS_detail_texture' => [
                                         'glDetailTexFuncSGIS',
                                         'glGetDetailTexFuncSGIS'

--- a/utils/generate-XS.pl
+++ b/utils/generate-XS.pl
@@ -103,7 +103,7 @@ for my $file (@headers) {
 
                           # typedef void* (GLAPIENTRY * PFNGLMAPBUFFERPROC) (GLenum target, GLenum access);
                           # typedef void (GLAPIENTRY * PFNGLGETQUERYIVPROC) (GLenum target, GLenum pname, GLint* params);
-        } elsif( $line =~ /^typedef ([*\w]+) \(GLAPIENTRY \* PFN(\w+)PROC\)\s*\((.*)\);/ ) {
+        } elsif( $line =~ /^typedef ([\w]+(?:\s*\*)?) \(GLAPIENTRY \* PFN(\w+)PROC\)\s*\((.*)\);/ ) {
             my( $restype, $name, $sig ) = ($1,$2,$3);
             my $s = { signature => $sig, restype => $restype, feature => $feature_name, name => $name };
             $signature{ $name } = $s;


### PR DESCRIPTION
The previous regex was wrong in that it allowed the "*" in "void *" at every place while not allowing for whitespace between "void" and "*". This changeset fixes that.