### PR TITLE
Add some distribution metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ MYMETA.*
 Makefile
 Makefile.old
 OpenGL-Modern-*.tar.gz
+OpenGL-Modern-*/
 *.bs
 *.o
 blib/

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,7 @@ if( os_is('MSWin32')) {
 
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
-WriteMakefile(
+WriteMakefile1(
     NAME              => 'OpenGL::Modern',
     VERSION_FROM      => 'lib/OpenGL/Modern.pm',
     PREREQ_PM         => {
@@ -4088,4 +4088,31 @@ else {
     my $fallback = File::Spec->catfile('fallback', $file);
     copy ($fallback, $file) or die "Can't copy $fallback to $file: $!";
   }
+}
+
+sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.21. Added by eumm-upgrade.
+    my %params=@_;
+    my $eumm_version=$ExtUtils::MakeMaker::VERSION;
+    $eumm_version=eval $eumm_version;
+    die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
+    die "License not specified" if not exists $params{LICENSE};
+    if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
+        #EUMM 6.5502 has problems with BUILD_REQUIRES
+        $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };
+        delete $params{BUILD_REQUIRES};
+    }
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.64) {
+        $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
+    delete $params{CONFIGURE_REQUIRES} if $eumm_version < 6.52;
+    delete $params{MIN_PERL_VERSION} if $eumm_version < 6.48;
+    delete $params{META_MERGE} if $eumm_version < 6.46;
+    delete $params{META_ADD} if $eumm_version < 6.46;
+    delete $params{LICENSE} if $eumm_version < 6.31;
+    delete $params{AUTHOR} if $] < 5.005;
+    delete $params{ABSTRACT_FROM} if $] < 5.005;
+    delete $params{BINARY_LOCATION} if $] < 5.005;
+
+    WriteMakefile(%params);
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,22 @@ if( os_is('MSWin32')) {
 WriteMakefile1(
     NAME              => 'OpenGL::Modern',
     VERSION_FROM      => 'lib/OpenGL/Modern.pm',
+    ABSTRACT_FROM     => 'lib/OpenGL/Modern.pm', # retrieve abstract from module
+    AUTHOR            => 'Max Maischein <corion@cpan.org>',
+    LICENSE           => 'perl',
+    META_MERGE => {
+        "meta-spec" => { version => 2 },
+        resources => {
+            repository => {
+                web => 'https://github.com/devel-chm/OpenGL-Modern',
+                url => 'git@github.com:devel-chm/OpenGL-Modern.git',
+                type => 'git',
+            }
+        },
+    },
+
+    MIN_PERL_VERSION => '5.006',
+
     PREREQ_PM         => {
       'OpenGL'                  => '0.7',  # only use latest version
       'Prima'                   => 0,
@@ -31,9 +47,6 @@ WriteMakefile1(
       'Filter::signatures'      => '0.07', # for empty function signatures
       'Carp' => 0,
     }, # e.g., Module::Name => 1.1
-    ABSTRACT_FROM     => 'lib/OpenGL/Modern.pm', # retrieve abstract from module
-    AUTHOR            => 'Max Maischein <corion@cpan.org>',
-    LICENSE           => 'perl',
     #Value must be from legacy list of licenses here
     #http://search.cpan.org/perldoc?Module%3A%3ABuild%3A%3AAPI
     LIBS              => "@libs", # e.g., '-lm'
@@ -41,6 +54,9 @@ WriteMakefile1(
     INC               => $include,
     CONFIGURE_REQUIRES    => {
         'Devel::CheckOS' => 0,
+        'ExtUtils::MakeMaker' => 0,
+    },
+    BUILD_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
     },
     XSPROTOARG => '-prototypes',


### PR DESCRIPTION
This addresses the repository link, but I don't know how to add other resources.

I have not checked in the META.* files. I'm not sure if you want them in the repository itself. Personally, I like the repository to contain all files that make up the distribution, but I know that there are other approaches.

I switched the Makefile.PL to a version that purports to be compatible with more versions of ExtUtils::MakeMaker, but that change is easily reverted later.