### PR TITLE
make tests less noisy by switching non-emergency diag/warn calls to note()

### DIFF
--- a/t/01_context.t
+++ b/t/01_context.t
@@ -18,4 +18,4 @@ glewInit();
 my $opengl_version = glGetString(GL_VERSION);
 isn't '', $opengl_version;
 
-diag "We got OpenGL version $opengl_version";
+note "We got OpenGL version $opengl_version";

--- a/t/02_glGetShaderInfoLog.t
+++ b/t/02_glGetShaderInfoLog.t
@@ -8,7 +8,7 @@ glewInit();
 
 # Set up a windowless OpenGL context?!
 my $id = glCreateShader(GL_VERTEX_SHADER);
-diag "Got vertex shader $id, setting source";
+note "Got vertex shader $id, setting source";
 
 my $shader = <<SHADER;
 int i;
@@ -20,7 +20,7 @@ glShaderSource($id, 1, pack('P',$shader), pack('I',$shader_length));
 
 glCompileShader($id);
     
-warn "Looking for errors";
+note "Looking for errors";
 glGetShaderiv($id, GL_COMPILE_STATUS, (my $ok = "\0" x 8));
 $ok = unpack 'I', $ok;
 if( $ok == GL_FALSE ) {
@@ -32,7 +32,7 @@ if( $ok == GL_FALSE ) {
     my $log = substr $buffer, 0, $len;
     isnt $log, '', "We get some error message";
       
-    diag "Error message: $log";
+    note "Error message: $log";
       
 } else {
     fail "We recognize an invalid shader as valid";


### PR DESCRIPTION
Various tests make use of diag and warn to print out debug info. That makes output on `dmake test` or `prove` unnecessarily noisy. This PR changes those instances to note(), which shows up only on verbose test runs.