### PR TITLE
perltidy and list extraction

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,5 @@
+--maximum-line-length=120
+--backup-and-modify-in-place
+--paren-tightness=0
+--output-line-ending=unix
+--indent-columns=4

--- a/t/0999_tidy.t
+++ b/t/0999_tidy.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::InDistDir;
+use Test::More 0.88;
+use IO::All -binary;
+use lib "t/lib";
+use Devel::Confess;
+
+SKIP: if ( !eval { require Capture::Tiny && require Perl::Tidy } ) {
+    skip "test requires Capture::Tiny and Perl::Tidy", 1;
+    exit;
+}
+
+SKIP: if ( $ENV{SKIP_TIDY_TESTS} ) {
+    skip "test skipped due to \$ENV{SKIP_TIDY_TESTS}", 1;
+    exit;
+}
+
+run();
+
+sub run {
+    note "set \$ENV{SKIP_TIDY_TESTS} to skip these";
+    eval { report_untidied_files() };
+    pass;
+    done_testing;
+}
+
+sub report_untidied_files {
+    require PerlTidyCheck;
+
+    return unless    #
+      my @untidied =
+      PerlTidyCheck::find_untidied_files( sub { grep !/^signatures.*XS.*sig.*\.pl$|NameLists.*\.pm$/, @_ } );
+
+    my $report = join "",    #
+      "found untidied files:", "\n\n", map( PerlTidyCheck::format_untidied_entry( $_ ), @untidied ), "\n";
+    diag $report;
+
+    return;
+}

--- a/t/lib/PerlTidyCheck.pm
+++ b/t/lib/PerlTidyCheck.pm
@@ -1,0 +1,87 @@
+package PerlTidyCheck;
+
+use strict;
+use warnings;
+
+use IO::All -binary;
+use Capture::Tiny 'capture_merged';
+use Perl::Tidy 'perltidy';
+use Test::More;
+
+sub format_untidied_entry {
+    my ( $untidied ) = @_;
+
+    my ( $file, $diff ) = @{$untidied};
+    $diff ||= "";
+
+    if ( $diff ) {
+        my @diff = split /\n/, $diff;
+        if ( @diff > 20 ) {
+            @diff = ( @diff[ 0 .. 19 ], "[... snip ...]\n" );
+            $diff = join "\n", "", @diff;
+        }
+        $file = ( "-" x 78 ) . "\n$file:\n";
+        $diff = $diff . ( "-" x 78 ) . "\n\n";
+    }
+
+    return "$file\n$diff";
+}
+
+sub find_untidied_files {
+    my ( $exclude_filter ) = @_;
+    my @perl = find_perl_files();
+    @perl = $exclude_filter->( @perl ) if $exclude_filter;
+    my @untidied = map time_check( $_ ), @perl;
+    return @untidied;
+}
+
+sub find_perl_files { grep !/\bblib\b/, grep /(^[^.]|\.(pl|PL|pm|t))$/, io( "." )->All_Files }
+
+sub time_check {
+    my ( $file ) = @_;
+    my $start    = time;
+    my @res      = check_tidy_status( $file );
+    note sprintf "%s - $file", time - $start;
+    return @res;
+}
+
+sub check_tidy_status {
+    my ( $file ) = @_;
+
+    my $source = $file->all;
+    my $tidy   = transform_source( $source );
+    return if $source eq $tidy;
+
+    return [ "$file", "" ] if !require Text::Diff;
+
+    my $diff = Text::Diff::diff( \$source, \$tidy, { Style => 'Unified' } );
+    return [ "$file", $diff ];
+}
+
+# from Code::TidyAll::Plugin::PerlTidy
+sub transform_source {
+    my ( $source ) = @_;
+
+    # perltidy reports errors in two different ways.
+    # Argument/profile errors are output and an error_flag is returned.
+    # Syntax errors are sent to errorfile or stderr, depending on the
+    # the setting of -se/-nse (aka --standard-error-output).  These flags
+    # might be hidden in other bundles, e.g. -pbp.  Be defensive and
+    # check both.
+    my ( $output, $error_flag, $errorfile, $stderr, $destination );
+    $output = capture_merged {
+        $error_flag = perltidy(
+            source      => \$source,
+            destination => \$destination,
+            stderr      => \$stderr,
+            errorfile   => \$errorfile
+        );
+    };
+    die $stderr          if $stderr;
+    die $errorfile       if $errorfile;
+    die $output          if $error_flag;
+    print STDERR $output if defined $output;
+    return $destination;
+}
+
+1;


### PR DESCRIPTION
This PR will probably need some discussion to see if it's appropriate in whole or part.

The code styles in the code as present are quite inconsistent. This PR consists primarily of two things:

1. Tidying of all files, as well as introduction of a test that never fails, only runs when its prerequisites are met, but if present, uses Perl::Tidy and others to check that all files of the project are tidied, and if not uses diag() to print out info about that. This way developers are informed, but can choose to ignore the warnings.

2. It also strips out the many GL function and constant lists and puts them into separate modules, then deduplicates them as much as possible. This is done to speed up tidying, but also to generally separate moving code from pure data storage, in order to make reading the code easier. Not quite happy with the names yet, but at the end of the process i ended up with one file containing the data extracted by generate-XS.pl, and in the other manually curated lists. An upside besides the previous ones from this is that the two can be diffed to check what differences there are between the glew lists and the manually curated ones (i.e. implementations).