### PR TITLE
make the shader error test fail to demonstrate xs_buffer does not work

### DIFF
--- a/t/02_glGetShaderInfoLog.t
+++ b/t/02_glGetShaderInfoLog.t
@@ -2,6 +2,7 @@
 use strict;
 use Test::More tests => 2;
 use OpenGL::Modern ':all';
+use OpenGL::Modern::Helpers 'xs_buffer';
 
 glewCreateContext();
 glewInit();
@@ -21,13 +22,13 @@ glShaderSource($id, 1, pack('P',$shader), pack('I',$shader_length));
 glCompileShader($id);
     
 warn "Looking for errors";
-glGetShaderiv($id, GL_COMPILE_STATUS, (my $ok = "\0" x 8));
+glGetShaderiv($id, GL_COMPILE_STATUS, xs_buffer(my $ok, 8));
 $ok = unpack 'I', $ok;
 if( $ok == GL_FALSE ) {
     pass "We recognize an invalid shader as invalid";
 
     my $bufsize = 1024*64;
-    glGetShaderInfoLog( $id, $bufsize, (my $len = "\0" x 8), (my $buffer = "\0" x $bufsize));
+    glGetShaderInfoLog( $id, $bufsize, xs_buffer(my $len, 8), xs_buffer(my $buffer, $bufsize));
     $len = unpack 'I', $len;
     my $log = substr $buffer, 0, $len;
     isnt $log, '', "We get some error message";


### PR DESCRIPTION
This PR transforms 02_glGetShaderInfoLog.t into a failing test under Strawberry 5.18.4 by making it use xs_buffer instead of setting the buffers up manually.

I have not tested if this works under other perl versions or not, and am generally unsure about the mechanism of action here.

What happens on my system is that apparently the scalars are set, but never passed on to the C function and thus remain as \x00 x $n. Output of the test accordingly looks like this:

```
t/02_glGetShaderInfoLog.t .. # Got vertex shader 1, setting source
Looking for errors at t/02_glGetShaderInfoLog.t line 24.
t/02_glGetShaderInfoLog.t .. 1/2
#   Failed test 'We get some error message'
#   at t/02_glGetShaderInfoLog.t line 34.
#          got: ''
#     expected: anything else
# Error message:
```

Moving the xs_buffer calls into their own line like so causes the test to pass again:

```
    xs_buffer(my $len, 8);
    xs_buffer(my $buffer, $bufsize);
    glGetShaderInfoLog( $id, $bufsize, $len, $buffer);
```

Any idea @Corion?