### PR TITLE
use Devel::CheckLib to generate NA on missing libs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,7 @@ use lib 'lib';
 use OpenGL::Modern::NameLists::MakefileAll;
 use Capture::Tiny 'capture';
 use ExtUtils::Constant ();
+use Devel::CheckLib 'assert_lib';
 
 my $include = "-I. -Iinclude -Isrc";
 my $libs;
@@ -105,6 +106,8 @@ sub WriteMakefile1 {    #Written by Alexandr Ciornii, version 0.21. Added by eum
     delete $params{AUTHOR}             if $] < 5.005;
     delete $params{ABSTRACT_FROM}      if $] < 5.005;
     delete $params{BINARY_LOCATION}    if $] < 5.005;
+
+    die "$@\nOS unsupported\n" if not eval { assert_lib %params; 1 };
 
     WriteMakefile( %params );
 }

--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ on configure => sub {
     requires 'ExtUtils::Constant'            => 0;
     requires 'ExtUtils::MakeMaker'           => '6.17';
     requires 'ExtUtils::MakeMaker::CPANfile' => 0;
+    requires 'Devel::CheckLib'               => 0;
 };
 
 on test => sub {


### PR DESCRIPTION
This fixes #39.

The idea here is that missing libs should generate `NA` reports, instead of the `UNKNOWN` caused by errors in the `make` phase.