### PR TITLE
hack module to allow OpenGL::Image to seamlessly use OpenGL::Modern

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 requires 'Carp' => 0;
+requires 'Import::Into' => 0;
 
 on configure => sub {
     requires 'Capture::Tiny'                 => 0;

--- a/lib/OpenGL/Modern.pm
+++ b/lib/OpenGL/Modern.pm
@@ -106,6 +106,20 @@ Much of the functionality that used to be accessed via the
 extension mechanism in C<OpenGL> now is standardized and
 in the OpenGL Core APIs.
 
+=head2 OpenGL::Image
+
+The module OpenGL::Image was written for the original OpenGL.pm, however it can
+be made to work seamlessly with OpenGL::Modern. Where-as you previously loaded
+it like this:
+
+    use OpenGL::Image;             # loads OpenGL.pm on its own
+
+You can prepend two use lines, and get this:
+
+    use OpenGL::Array;             # not part of OpenGL::Modern
+    use OpenGL::Modern::ImageHack; # sets up a fake OpenGL namespace
+    use OpenGL::Image;             # now safe to do, won't load OpenGL.pm
+
 =head2 EXPORT
 
 None by default.

--- a/lib/OpenGL/Modern/ImageHack.pm
+++ b/lib/OpenGL/Modern/ImageHack.pm
@@ -1,0 +1,17 @@
+package    # hide from cpan
+  OpenGL;
+use strict;
+use warnings;
+use Import::Into;
+
+BEGIN {    # prevent the real one from being loaded
+    die "OpenGL already loaded" if $INC{"OpenGL.pm"};
+    $INC{"OpenGL.pm"} = "Loaded from OpenGL::Modern";
+}
+
+sub import {
+    my ( undef, @args ) = @_;
+    $args[0] = ':all' if $args[0] eq ':constants';    # O::M doesn't have :constants yet
+    my $target = caller;
+    OpenGL::Modern->import::into( $target, @args );
+}


### PR DESCRIPTION
I mentioned this yesterday and here it is. It is exceedingly simple.

It sets up a fake OpenGL namespace and blocks the %INC entry so it won't be overloaded by the real OpenGL.pm. Then it installs a barebones import method that simply rewrites it into an import on OpenGL::Modern, executed in the namespace of the caller. That way any import calls to the OpenGL namespace result in the import being done from OpenGL::Modern into the caller.

Only niggle is that OpenGL::Modern has no :constants, so i had to munge that into :all.

What do you think?