### PR TITLE
second shot at XQuartz/OpenGL support with suggested env

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,11 @@ if ( $^O eq 'MSWin32' ) {
 } else {
   $libs = '-lGL -lX11';
 }
+
+$define .= ' ' . $ENV{OGLM_ADD_DEFINE} if defined $ENV{OGLM_ADD_DEFINE};
+$libs   .= ' ' . $ENV{OGLM_ADD_LIBS} if defined $ENV{OGLM_ADD_LIBS};
+$DYNS->{OTHERLDFLAGS} = $ENV{OGLM_REPLACE_OTHERLDFLAGS} if defined $ENV{OGLM_REPLACE_OTHERLDFLAGS};
+
 my %buildargs = (
   !$libs ? () : (LIBS => $libs),
   DEFINE           => $define,


### PR DESCRIPTION
As agreed in https://github.com/Perl-GPU/OpenGL-Modern/pull/66, here's the next iteration that would allow linking the module with XQuartz libraries.

The intended use is this:

  env:
      OGLM_ADD_DEFINE: '-DGLEW_APPLE_GLX -I/opt/X11/include'
      OGLM_ADD_LIBS:   '-L/opt/X11/lib -lglut'
      OGLM_REPLACE_OTHERLDFLAGS: ''